### PR TITLE
add option 'keys' to force ordering

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -65,7 +65,20 @@ var data = {
 
 console.log();
 console.log(bars(data, { bar: '*', width: 20, sort: true, map: bytes }));
+
+// force order
+
+var data = {
+  ferrets: 20,
+  cats: 12,
+  dogs: 30,
+  koalas: 3
+};
+
+console.log();
+console.log(bars(data, { keys: ['cats', 'dogs', 'ferrets'] }));
 ```
+
 
 # License
 

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function histogram(data, opts) {
 
   // normalize data
 
-  var data = toArray(data);
+  var data = toArray(data, opts.keys || Object.keys(data));
   if (opts.sort) data = data.sort(descending);
 
   var maxKey = max(data.map(function(d){ return d.key.length }));
@@ -79,8 +79,8 @@ function max(data) {
  * Turn object into an array.
  */
 
-function toArray(obj) {
-  return Object.keys(obj).map(function(key){
+function toArray(obj, keys) {
+  return keys.map(function(key){
     return {
       key: key,
       val: obj[key]

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "license": "MIT",
   "scripts": {
-    "test": "node test.js"
+    "test": "mocha test.js"
   }
 }

--- a/test.js
+++ b/test.js
@@ -33,6 +33,16 @@ describe('bars', function () {
     bars(data, { width: 10, sort: true }).should.equal(expected);
   });
 
+  it('it should use keys in order', function () {
+    var data = { d: 1, e: 6, '0': 7 };
+    var expected = '\
+  d | #          | 1\n\
+  e | #########  | 6\n\
+  0 | ########## | 7\n\
+';
+    bars(data, { width: 10, keys: ['d', 'e', '0'] }).should.equal(expected);
+  });
+
   it('it should map values', function () {
     var data = {
       '/srv': bytes('5gb'),

--- a/test.js
+++ b/test.js
@@ -1,20 +1,69 @@
-var assert = require('assert');
+var should = require('should');
 var bars = require('./index');
+var bytes = require('bytes');
 
-var options = {width: 10};
+describe('bars', function () {
 
-var zeros = {a: 0, b: 0};
-var zerosExpected = '\
+  it('it should display bars', function () {
+    var data = { aa: 10, bbbbb: 999, c: 88 };
+    var expected = '\
+     aa |            | 10\n\
+  bbbbb | ########## | 999\n\
+      c | #          | 88\n\
+';
+    bars(data, { width: 10 }).should.equal(expected);
+  });
+
+  it('it should customize output', function () {
+    var data = { d: 1, e: 6 };
+    var expected = '\
+  d | ===             | 1\n\
+  e | =============== | 6\n\
+';
+    bars(data, { width: 15, bar: '=' }).should.equal(expected);
+  });
+
+  it('it should sort output', function () {
+    var data = { d: 1, e: 6, f: 3 };
+    var expected = '\
+  e | ########## | 6\n\
+  f | #####      | 3\n\
+  d | ##         | 1\n\
+';
+    bars(data, { width: 10, sort: true }).should.equal(expected);
+  });
+
+  it('it should map values', function () {
+    var data = {
+      '/srv': bytes('5gb'),
+      '/data': bytes('150gb'),
+      '/etc': bytes('150mb')
+    };
+    var expected = '\
+  /data | ******************** | 150gb\n\
+   /srv | *                    | 5gb\n\
+   /etc |                      | 150mb\n\
+';
+    bars(data, { bar: '*', width: 20, sort: true, map: bytes }).should.equal(expected);
+  });
+
+
+  it('it should handle all zeros', function () {
+    var data = { a: 0, b: 0 };
+    var expected = '\
   a |            | 0\n\
   b |            | 0\n\
 ';
-assert.equal(bars(zeros, options), zerosExpected, 'it should handle all zeros');
+    bars(data, { width: 10 }).should.equal(expected);
+  });
 
-var zeroFive = {a: 0, b: 5};
-var zeroFiveExpected = '\
+  it('it should handle a single zero', function () {
+    var data = { a: 0, b: 5 };
+    var expected = '\
   a |            | 0\n\
   b | ########## | 5\n\
 ';
-assert.equal(bars(zeroFive, options), zeroFiveExpected, 'it should handle a single zero');
+    bars(data, { width: 10 }).should.equal(expected);
+  });
 
-console.log('PASS');
+});


### PR DESCRIPTION
currently there is no way to force that lines are printed in a given order.
Specifically, `Object.keys` does not guarantee that keys are returned in insertion order (for example, on chrome and node, keys with numeric names e.g. `'0'` are returned first and in sort order).
This patch add a 'keys' option to force ordering
```js
var data = {
  ferrets: 20,
  cats: 12,
  dogs: 30,
  koalas: 3
};
console.log(bars(data, { keys: ['cats', 'dogs', 'ferrets'] }));
```
